### PR TITLE
separated auth object from client, shouldn't need to reauth every single...

### DIFF
--- a/linkedin/linkedin.py
+++ b/linkedin/linkedin.py
@@ -122,11 +122,11 @@ class LinkedInSelector(object):
 
 
 class LinkedInApplication(object):
-    def __init__(self, authentication):
-        assert authentication, 'Authentication instance must be provided'
-        assert type(authentication) == LinkedInAuthentication, 'Auth type mismatch'
+    def __init__(self, access_token):
+        assert access_token, 'models.AccessToken instance must be provided'
+        assert type(access_token) == AccessToken, 'AccessToken type mismatch'
         self.BASE_URL = 'https://api.linkedin.com'
-        self.authentication = authentication
+        self.access_token = access_token
 
     def request_succeeded(self, response):
         return not (('error' in response) or ('errorCode' in response))
@@ -139,9 +139,9 @@ class LinkedInApplication(object):
             headers.update({'x-li-format': 'json', 'Content-Type': 'application/json'})
 
         if params is None:
-            params = {'oauth2_access_token': self.authentication.token.access_token}
+            params = {'oauth2_access_token': self.access_token.access_token}
         else:
-            params['oauth2_access_token'] = self.authentication.token.access_token
+            params['oauth2_access_token'] = self.access_token.access_token
 
         return requests.request(method.upper(), url, data=data, params=params,
                                 headers=headers, timeout=timeout)

--- a/linkedin/server.py
+++ b/linkedin/server.py
@@ -19,20 +19,19 @@ def quick_api(api_key, secret_key):
     """
     auth = LinkedInAuthentication(api_key, secret_key, 'http://localhost:8000/',
                                   PERMISSIONS.enums.values())
-    app = LinkedInApplication(authentication=auth)
     print auth.authorization_url
-    _wait_for_user_to_enter_browser(app)
-    return app
+    _wait_for_user_to_enter_browser(auth)
+    access_token = auth.get_access_token()
+    return LinkedInApplication(access_token=access_token)
 
 
-def _wait_for_user_to_enter_browser(app):
+def _wait_for_user_to_enter_browser(auth):
     class MyHandler(BaseHTTPServer.BaseHTTPRequestHandler):
         def do_GET(self):
             p = self.path.split('?')
             if len(p) > 1:
                 params = cgi.parse_qs(p[1], True, True)
-                app.authentication.authorization_code = params['code'][0]
-                app.authentication.get_access_token()
+                auth.authorization_code = params['code'][0]
 
     server_address = ('', 8000)
     httpd = BaseHTTPServer.HTTPServer(server_address, MyHandler)


### PR DESCRIPTION
Requiring instantiation of LinkedInAuthentication and going through the OAuth flow every single time someone uses the API is overkill -- especially if authenticated operations are being performed in HTTP requests of a 3rd party application.
