### PR TITLE
Fix params being ignored.

### DIFF
--- a/linkedin/linkedin.py
+++ b/linkedin/linkedin.py
@@ -160,7 +160,7 @@ class LinkedInApplication(object):
         else:
             headers.update({'x-li-format': 'json', 'Content-Type': 'application/json'})
 
-        params = {} 
+        params = params or {} 
         kw = dict(data=data, params=params,
                   headers=headers, timeout=timeout)
 


### PR DESCRIPTION
Closes #25 which led to things like:

```
application.search_company(selectors=[{'companies': ['name', 'industry']}], params={'keywords': 'dskjfhsfhskdhfksdhfsd'})
```

returning all results.
