### PR TITLE
bugfix on make_request function.

### DIFF
--- a/linkedin/linkedin.py
+++ b/linkedin/linkedin.py
@@ -160,7 +160,9 @@ class LinkedInApplication(object):
         else:
             headers.update({'x-li-format': 'json', 'Content-Type': 'application/json'})
 
-        params = {} 
+        if params is None:
+            params = {} 
+        
         kw = dict(data=data, params=params,
                   headers=headers, timeout=timeout)
 


### PR DESCRIPTION
If params is always set to to empty, params passed will never used.
