### PR TITLE
Passes OAuth parameters as query parameters when getting access token

### DIFF
--- a/linkedin/linkedin.py
+++ b/linkedin/linkedin.py
@@ -116,7 +116,7 @@ class LinkedInAuthentication(object):
               'client_id': self.key,
               'client_secret': self.secret}
         try:
-            response = requests.post(self.ACCESS_TOKEN_URL, data=qd, timeout=timeout)
+            response = requests.post(self.ACCESS_TOKEN_URL + '?' + urllib.urlencode(qd), timeout=timeout)
             response.raise_for_status()
             response = response.json()
         except (requests.HTTPError, requests.ConnectionError), error:


### PR DESCRIPTION
This resolves an ongoing issue with the LinkedIn API where tokens were not functioning immediately after they were acquired. See: http://developer.linkedin.com/forum/unauthorized-invalid-or-expired-token-immediately-after-receiving-oauth2-token

This also is consistent with the LinkedIn documentation: https://developer.linkedin.com/documents/authentication
