### PR TITLE
Added getting a single network update by key, get_network_update

### DIFF
--- a/linkedin/linkedin.py
+++ b/linkedin/linkedin.py
@@ -441,6 +441,23 @@ class LinkedInApplication(object):
         raise_for_error(response)
         return response.json()
 
+    def get_network_update(self, types, update_key, 
+                            self_scope=True, params=None, headers=None):
+        url = '%s/~/network/updates/key=%s' % (ENDPOINTS.PEOPLE, str(update_key))
+
+        if not params:
+            params = {}
+
+        if types:
+            params.update({'type': types})
+
+        if self_scope is True:
+            params.update({'scope': 'self'})
+
+        response = self.make_request('GET', url, params=params, headers=headers)
+        raise_for_error(response)
+        return response.json()
+
     def get_network_status(self, params=None, headers=None):
         url = '%s/~/network/network-stats' % ENDPOINTS.PEOPLE
         response = self.make_request('GET', url, params=params, headers=headers)


### PR DESCRIPTION
For post tracking, it is often convenient to grab only one post instead of paging through all.  I added a function to make use of the /key=<update_key> URL since this format does not match normal parameter format that the params dict uses.
