### PR TITLE
Throw different exceptions based on error code in response

### DIFF
--- a/linkedin/exceptions.py
+++ b/linkedin/exceptions.py
@@ -1,3 +1,37 @@
 # -*- coding: utf-8 -*-
+
 class LinkedInError(Exception):
     pass
+
+class LinkedInBadRequestError(LinkedInError):
+    pass
+
+class LinkedInUnauthorizedError(LinkedInError):
+    pass
+
+class LinkedInPaymentRequiredError(LinkedInError):
+    pass
+
+class LinkedInNotFoundError(LinkedInError):
+    pass
+
+class LinkedInConflictError(LinkedInError):
+    pass
+
+class LinkedInForbiddenError(LinkedInError):
+    pass
+
+class LinkedInInternalServiceError(LinkedInError):
+    pass
+
+ERROR_CODE_EXCEPTION_MAPPING = {
+            400: LinkedInBadRequestError,
+            401: LinkedInUnauthorizedError,
+            402: LinkedInPaymentRequiredError,
+            403: LinkedInForbiddenError,
+            404: LinkedInNotFoundError,
+            409: LinkedInForbiddenError,
+            500: LinkedInInternalServiceError}
+
+def get_exception_for_error_code(error_code):
+    return ERROR_CODE_EXCEPTION_MAPPING.get(error_code, LinkedInError)

--- a/linkedin/utils.py
+++ b/linkedin/utils.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 import requests
-from .exceptions import LinkedInError
+from .exceptions import LinkedInError, get_exception_for_error_code
 
 try:
     from cStringIO import StringIO
@@ -60,7 +60,9 @@ def raise_for_error(response):
             if ('error' in response) or ('errorCode' in response):
                 message = '%s: %s' % (response.get('error', error.message),
                                       response.get('error_description', 'Unknown Error'))
-                raise LinkedInError(message)
+                error_code = response.get('status')
+                ex = get_exception_for_error_code(error_code)
+                raise ex(message)
             else:
                 raise LinkedInError(error.message)
         except (ValueError, TypeError):


### PR DESCRIPTION
All error codes that I can find in the documentation are separated with their own exception classes, based on these two pages:

https://developer.linkedin.com/documents/handling-errors-invalid-tokens
https://developer.linkedin.com/documents/error-codes

All new exception classes subclass LinkedInError for backward compatibility.
