### PR TITLE
Fix bug with submitted-image-url being empty or None

### DIFF
--- a/linkedin/linkedin.py
+++ b/linkedin/linkedin.py
@@ -292,11 +292,13 @@ class LinkedInApplication(object):
             'title': title, 'summary': summary,
             'content': {
                 'submitted-url': submitted_url,
-                'submitted-image-url': submitted_image_url,
                 'title': content_title,
                 'description': description
             }
         }
+        if submitted_image_url:
+            post['content']['submitted-image-url'] = submitted_image_url
+
         url = '%s/%s/posts' % (ENDPOINTS.GROUPS, str(group_id))
         response = self.make_request('POST', url, data=json.dumps(post))
         raise_for_error(response)
@@ -402,9 +404,10 @@ class LinkedInApplication(object):
             post['content'] = {
                 'title': title,
                 'submitted-url': submitted_url,
-                'submitted-image-url': submitted_image_url,
                 'description': description,
             }
+        if submitted_image_url:
+            post['content']['submitted-image-url'] = submitted_image_url
 
         url = '%s/%s/shares' % (ENDPOINTS.COMPANIES, company_id)
 
@@ -451,9 +454,10 @@ class LinkedInApplication(object):
             post['content'] = {
                 'title': title,
                 'submitted-url': submitted_url,
-                'submitted-image-url': submitted_image_url,
                 'description': description,
             }
+        if submitted_image_url:
+            post['content']['submitted-image-url'] = submitted_image_url
 
         url = '%s/~/shares' % ENDPOINTS.PEOPLE
         response = self.make_request('POST', url, data=json.dumps(post))


### PR DESCRIPTION
Linkedin changed their API lately, and now submitting a share with an empty `submitted-image-url` returns the following error: `linkedin.exceptions.LinkedInBadRequestError: 400 Client Error: Bad Request: &#39;submitted-image-url&#39; can not be empty`

Not passing `submitted-image-url` in the post fields if it's not set fixes this.