### PR TITLE
Remove LinkedIn permission that are no longer in API

### DIFF
--- a/linkedin/linkedin.py
+++ b/linkedin/linkedin.py
@@ -22,13 +22,9 @@ __all__ = ['LinkedInAuthentication', 'LinkedInApplication', 'PERMISSIONS']
 PERMISSIONS = enum('Permission',
                    COMPANY_ADMIN='rw_company_admin',
                    BASIC_PROFILE='r_basicprofile',
-                   FULL_PROFILE='r_fullprofile',
                    EMAIL_ADDRESS='r_emailaddress',
-                   NETWORK='r_network',
-                   CONTACT_INFO='r_contactinfo',
-                   NETWORK_UPDATES='rw_nus',
-                   GROUPS='rw_groups',
-                   MESSAGES='w_messages')
+                   CONTACT_INFO='w_share',
+                   )
 
 ENDPOINTS = enum('LinkedInURL',
                  PEOPLE='https://api.linkedin.com/v1/people',


### PR DESCRIPTION
Remove LinkedIn permission that are no longer in API — https://developer.linkedin.com/support/developer-program-transition
